### PR TITLE
feat: Add setting to prompt the user for sentry consent

### DIFF
--- a/layout/pages/settings/interface.xml
+++ b/layout/pages/settings/interface.xml
@@ -69,6 +69,19 @@
 					<Label text="#Settings_Menu_Type1" value="1" id="bgtype1" />
 				</ChaosSettingsEnumDropDown>
 
+				<!-- TODO: LOCALISE AND MOVE THIS SOMEWHERE ELSE!!!! -->
+				<ChaosSettingsEnum
+					id="SentryReporting"
+					text="Sentry Crash Reporting"
+					infomessage="Sentry"
+					hasdocspage="false"
+					tags="sentry"
+				>
+					<Button class="button horizontal-align-right" onactivate="SettingsShared.sentryUpdateConsent()">
+						<Label class="button__text" text="Update Consent" />
+					</Button>
+				</ChaosSettingsEnum>
+
 			</Panel>
 
 			<Panel class="settings-page__spacer" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "momentum-panorama",
+	"name": "p2ce-panorama",
 	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "momentum-panorama",
+			"name": "p2ce-panorama",
 			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "momentum-panorama",
+	"name": "p2ce-panorama",
 	"version": "1.0.0",
-	"description": "Scripts for handling Momentum Panorama files",
+	"description": "Scripts for handling P2CE Panorama files",
 	"config": {
 		"baseDir": "./"
 	},
@@ -11,11 +11,9 @@
 		"lint:fix": "eslint \"**/*.js\" --fix",
 		"lint:check": "eslint \"**/*.js\"",
 		"prepare": "husky install",
-		"pre-commit": "lint-staged",
-		"get-learn": "node tools/get-learn.js",
-		"get-credits": "node tools/get-credits.js"
+		"pre-commit": "lint-staged"
 	},
-	"author": "Momentum Team",
+	"author": "P2CE & Momentum Team",
 	"license": "MIT",
 	"dependencies": {},
 	"devDependencies": {

--- a/scripts/pages/settings/page.js
+++ b/scripts/pages/settings/page.js
@@ -227,4 +227,24 @@ class SettingsShared {
 			'ConVarColorDisplay'
 		].includes(panel.paneltype);
 	}
+
+	static sentryUpdateConsent() {
+		// Don't even bother asking if sentry isn't enabled
+		if (!SentryAPI.IsSentryActive()) {
+			return;
+		}
+
+		UiToolkitAPI.ShowGenericPopupYesNo(
+			'Sentry Consent',
+			'Allow automatic upload of crash dumps?' +
+				'\n\nCrash dumps contain game path information and the SteamID of the currently logged in Steam account.',
+			'wide-popup',
+			() => {
+				GameInterfaceAPI.ConsoleCommand('sentry_consent_give');
+			},
+			() => {
+				GameInterfaceAPI.ConsoleCommand('sentry_consent_revoke');
+			}
+		);
+	}
 }


### PR DESCRIPTION
relies on internal red pr. only merge when that's merged too