### PR TITLE
Change styling to match p2ce branding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 .vs/
+.vscode/
 node_modules/
+pnpm-lock.yaml
 fonts.uuid
 .uuid
 conf.d

--- a/fonts/fonts.conf
+++ b/fonts/fonts.conf
@@ -17,13 +17,13 @@
 
 	=== Recommended Setup ===
 	Run ./infctl.sh script located in the current directory to set the style.
-	
+
 	# ./infctl.sh setstyle
-	
+
 	=== Manual Setup ===
-	See the infinality/styles.conf.avail/ directory for all options.  To enable 
+	See the infinality/styles.conf.avail/ directory for all options.  To enable
 	a different style, remove the symlink "conf.d" and link to another style:
-	
+
 	# rm conf.d
 	# ln -s styles.conf.avail/win7 conf.d
 	-->
@@ -35,13 +35,14 @@
 	<dir prefix="xdg">fonts</dir>
 
 	<!-- A fontpattern is a font file name, not a font name.  Be aware of filenames across all platforms! -->
-	<!-- CHAOSTODO: Port fontpatterns, or at least implement them, in a fork of fontconfig 
+	<!-- CHAOSTODO: Port fontpatterns, or at least implement them, in a fork of fontconfig
 	<fontpattern>Arial</fontpattern>
 	<fontpattern>.vfont</fontpattern>
 	<fontpattern>notosans</fontpattern>
+	<fontpattern>Roboto</fontpattern>
 	<fontpattern>notoserif</fontpattern>
 	<fontpattern>notomono-regular</fontpattern> -->
-	
+
 	<cachedir>WINDOWSTEMPDIR_FONTCONFIG_CACHE</cachedir>
 	<cachedir>~/.fontconfig</cachedir>
 
@@ -178,17 +179,17 @@
 		</edit>
 	</match>
 
-	<!-- Ban Type-1 fonts because they render poorly --> 
+	<!-- Ban Type-1 fonts because they render poorly -->
 	<!-- Comment this out to allow all Type 1 fonts -->
-	<selectfont> 
-		<rejectfont> 
-			<pattern> 
-				<patelt name="fontformat" > 
-					<string>Type 1</string> 
-				</patelt> 
-			</pattern> 
-		</rejectfont> 
-	</selectfont> 
+	<selectfont>
+		<rejectfont>
+			<pattern>
+				<patelt name="fontformat" >
+					<string>Type 1</string>
+				</patelt>
+			</pattern>
+		</rejectfont>
+	</selectfont>
 
 	<!-- Globally use embedded bitmaps in fonts like Calibri? -->
 	<match target="font" >
@@ -237,7 +238,7 @@
 			<double>96</double>
 		</edit>
 	</match>
-	
+
 	<!-- Use Qt subpixel positioning on autohinted fonts? -->
 	<!-- This only applies to Qt and autohinted fonts. Qt determines subpixel positioning based on hintslight vs. hintfull, -->
 	<!--   however infinality patches force slight hinting inside freetype, so this essentially just fakes out Qt. -->

--- a/styles/components/settings.scss
+++ b/styles/components/settings.scss
@@ -79,7 +79,7 @@
 		& > RadioButton {
 			@extend .button;
 			@extend .radiobutton;
-			@extend .radiobutton--blue;
+			@extend .radiobutton--orange;
 
 			width: fit-children;
 			min-width: 140px;
@@ -151,12 +151,12 @@
 		transition-timing-function: ease-in-out;
 
 		&:hover {
-			background-color: rgba($blue, 0.3);
-			border: 1px solid rgba($blue, 0.4);
+			background-color: rgba($orange, 0.3);
+			border: 1px solid rgba($orange, 0.4);
 		}
 
 		#{$root}:selected & {
-			animation-name: PulseBackgroundBlue;
+			animation-name: PulseBackgroundOrange;
 			animation-duration: 1.5s;
 			animation-timing-function: linear;
 			animation-iteration-count: infinite;

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -510,7 +510,7 @@ $scrollbar-hover-opacity: 0.8 !default;
 
 $progressbar-width: 320px !default;
 $progressbar-height: 22px !default;
-$progressbar-background: color.scale($orange, $saturation: -70%, $lightness: -50%) !default;
+$progressbar-background: $gray-300 !default;
 $progressbar-background-disabled: gradient(
 	linear,
 	0% 0%,

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -302,10 +302,7 @@ $button-icon-shadow: 0 1px 2px 1 rgba(0, 0, 0, 1) !default;
 $dropdown-button-background: $button-background !default;
 
 $dropdown-button-background-disabled: $button-background-disabled !default;
-$dropdown-button-background-hover: gradient-vertical(
-	color.scale($button-background-base, $lightness: 0%, $alpha: 15%),
-	color.scale($button-background-base, $lightness: -20%, $alpha: 15%)
-) !default;
+$dropdown-button-background-hover: $button-background-hover !default;
 $dropdown-button-background-menuvisible: gradient-vertical(
 	color.scale($button-background-base, $lightness: -60%, $alpha: 50%),
 	color.scale($button-background-base, $lightness: -65%, $alpha: 50%)

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -180,9 +180,9 @@ $font-default-color: $white !default;
 $font-disabled-color: color.scale($font-default-color, $lightness: -20%) !default;
 $font-default-size: 18px !default;
 
-$font-primary: 'Noto Sans' !default;
-$font-secondary: 'Noto Sans', Arial, sans-serif !default;
-$font-secondary-light: 'Noto Sans', Arial, sans-serif !default;
+$font-primary: 'Roboto' !default;
+$font-secondary: 'Roboto', Arial, sans-serif !default;
+$font-secondary-light: 'Roboto', Arial, sans-serif !default;
 $font-monospace: 'Roboto Mono' !default;
 
 $font-header: $font-secondary !default;

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -12,8 +12,9 @@ $light-blue: #71f0ff !default;
 $purple: #be71ff !default;
 $pink: #ffb6dc !default;
 $red: #ff6a6a !default;
-$orange: #ffbc00 !default;
-$yellow: #ffee00 !default;
+$orange: #ff7b02 !default;
+$mid-orange: #ffae64 !default;
+$yellow: #ffae64 !default;
 $green: #7aee7a !default;
 
 $colors-primary: (
@@ -142,8 +143,8 @@ $gradients-primary: (
 		#d31818
 	),
 	'orange': (
-		#ffbc00,
-		#dc740d
+		$mid-orange,
+		$orange
 	),
 	'yellow': (
 		#f8de4a,
@@ -263,14 +264,8 @@ $spacers: (4px, 6px, 8px, 16px, 32px) !default;
 // ================
 
 $button-background-base: $light-700 !default;
-$button-background: gradient-vertical(
-	$button-background-base,
-	color.scale($button-background-base, $lightness: -15%)
-) !default;
-$button-background-hover: gradient-vertical(
-	color.scale($button-background-base, $lightness: 0%, $alpha: 15%),
-	color.scale($button-background-base, $lightness: -20%, $alpha: 15%)
-) !default;
+$button-background: $button-background-base !default;
+$button-background-hover: $light-800 !default;
 $button-background-selected: gradient-vertical(
 	color.scale($button-background-base, $lightness: 0%, $alpha: 20%),
 	color.scale($button-background-base, $lightness: -20%, $alpha: 20%)
@@ -345,7 +340,7 @@ $dropdown-button-text-shadow: $button-text-shadow;
 $dropdown-button-padding: 4px 12px !default;
 $dropdown-button-icon-width: 24px !default;
 
-$dropdown-menu-background: $gray-100 !default;
+$dropdown-menu-background: $gray-400 !default;
 $dropdown-menu-padding-y: 8px !default;
 $dropdown-menu-shadow: fill rgba(0, 0, 0, 0.9) 0px 3px 6px 0px !default;
 $dropdown-menu-border: 1px solid rgba(0, 0, 0, 0.9) !default;
@@ -383,7 +378,7 @@ $checkbox-background: $light-600 !default;
 $checkbox-background-disabled: color.scale($checkbox-background, $lightness: -50%, $alpha: 20%) !default;
 $checkbox-background-disabled-selected: color.scale($checkbox-background-disabled, $alpha: 50%) !default;
 $checkbox-background-hover: color.scale($checkbox-background, $alpha: 20%) !default;
-$checkbox-background-selected: $blue !default;
+$checkbox-background-selected: $orange !default;
 $checkbox-background-selected-hover: color.scale($checkbox-background-selected, $lightness: -10%) !default;
 
 $checkbox-use-header-font: false !default;
@@ -483,8 +478,8 @@ $slider-track-height: 8px !default;
 
 $slider-track: $gray-900 !default;
 $slider-track-shadow: rgba(0, 0, 0, 0.2) 0px 0px 8px 0px !default;
-$slider-track-progress-horizontal: gradient-horizontal($blue, $mid-blue) !default;
-$slider-track-progress-vertical: gradient-vertical($blue, $mid-blue) !default;
+$slider-track-progress-horizontal: $orange !default;
+$slider-track-progress-vertical: $orange !default;
 
 $slider-thumb-color: $white !default;
 $slider-thumb-color-hover: color.scale($slider-thumb-color, $lightness: -15%) !default;
@@ -493,7 +488,7 @@ $slider-thumb-height: 16px !default;
 $slider-thumb-radius: 4px !default;
 $slider-thumb-shadow: rgba(0, 0, 0, 0.3) 0px 1px 2px 0px !default;
 
-$slider-default-color: $red !default;
+$slider-default-color: $gray-600 !default;
 $slider-default-width: 4px !default;
 $slider-default-height: 8px !default;
 $slider-default-radius: 0px !default;
@@ -515,7 +510,7 @@ $scrollbar-hover-opacity: 0.8 !default;
 
 $progressbar-width: 320px !default;
 $progressbar-height: 22px !default;
-$progressbar-background: color.scale($blue, $saturation: -70%, $lightness: -50%) !default;
+$progressbar-background: color.scale($orange, $saturation: -70%, $lightness: -50%) !default;
 $progressbar-background-disabled: gradient(
 	linear,
 	0% 0%,
@@ -523,7 +518,7 @@ $progressbar-background-disabled: gradient(
 	from(color.scale($red, $saturation: -65%, $lightness: -45%)),
 	to(color.scale($red, $saturation: -55%, $lightness: -35%))
 );
-$progressbar-background-progress: gradient(linear, 0% 0%, 100% 0%, from($blue), to($light-blue)) !default;
+$progressbar-background-progress: $orange !default;
 
 $progressbar-shadow: rgba(0, 0, 0, 0.5) 0px 0px 3px 0px !default;
 
@@ -531,7 +526,7 @@ $progressbar-shadow: rgba(0, 0, 0, 0.5) 0px 0px 3px 0px !default;
 // TOOLTIPS
 // ================
 
-$tooltip-background: $gray-200 !default;
+$tooltip-background: $gray-400 !default;
 $tooltip-padding: 8px 12px !default;
 $tooltip-radius: 4px !default;
 $tooltip-margin: 0px;
@@ -550,8 +545,7 @@ $popup-min-width: 400px !default;
 $popup-max-width: 480px !default;
 $popup-wide: 960px !default;
 $popup-large-max-width: 720px !default;
-$popup-background: $dark-800 !default;
-$popup-shadow: rgba(0, 0, 0, 1) -2.5px -2.5px 10px 5px !default;
+$popup-background: $gray-400 !default;
 $popup-padding: 24px 32px !default;
 $popup-radius: 4px !default;
 

--- a/styles/controls/button.scss
+++ b/styles/controls/button.scss
@@ -83,8 +83,8 @@
 	}
 }
 
-@each $name in map.keys($gradients-primary) {
+@each $name, $value in $gradients-primary {
 	.button--#{$name} {
-		@include mixin.button-gradient($color: $name);
+		background-color: list.nth($value, 1);
 	}
 }

--- a/styles/controls/radio-button.scss
+++ b/styles/controls/radio-button.scss
@@ -21,7 +21,7 @@
 @each $name, $colors in $gradients-primary {
 	.radiobutton--#{$name} {
 		&:selected {
-			background-color: function.gradient-vertical(list.nth($colors, 1), list.nth($colors, 2));
+			background-color: list.nth($colors, 2);
 			border: $button-border;
 		}
 	}

--- a/styles/controls/toggle-button.scss
+++ b/styles/controls/toggle-button.scss
@@ -28,23 +28,6 @@
 		&:selected {
 			background-color: function.gradient-vertical(list.nth($colors, 1), list.nth($colors, 2));
 			border: $button-border;
-
-			&:hover {
-				background-color: function.gradient-vertical(
-					color.scale(
-						list.nth($colors, 1),
-						$saturation: list.nth($gradient-hover-transform, 1),
-						$lightness: list.nth($gradient-hover-transform, 2),
-						$alpha: list.nth($gradient-hover-transform, 3)
-					),
-					color.scale(
-						list.nth($colors, 2),
-						$saturation: list.nth($gradient-hover-transform, 1),
-						$lightness: list.nth($gradient-hover-transform, 2),
-						$alpha: list.nth($gradient-hover-transform, 3)
-					)
-				);
-			}
 		}
 	}
 }

--- a/styles/core/animations.scss
+++ b/styles/core/animations.scss
@@ -42,17 +42,17 @@
 	}
 }
 
-@keyframes PulseBackgroundBlue {
+@keyframes PulseBackgroundOrange {
 	0% {
-		background-color: rgba($blue, 0.3);
+		background-color: rgba($orange, 0.3);
 	}
 
 	50% {
-		background-color: rgba($blue, 0.8);
+		background-color: rgba($orange, 0.8);
 	}
 
 	100% {
-		background-color: rgba($blue, 0.3);
+		background-color: rgba($orange, 0.3);
 	}
 }
 

--- a/styles/modals/popups/popup.scss
+++ b/styles/modals/popups/popup.scss
@@ -9,6 +9,7 @@
 	padding: $popup-padding;
 	border-radius: $popup-radius;
 	background-color: $popup-background;
+	box-shadow: 0 0 100px 0 $gray-200;
 	opacity: 1;
 	transition-property: pre-transform-scale2d, opacity;
 	transition-duration: 0.15s;

--- a/styles/modals/popups/popup.scss
+++ b/styles/modals/popups/popup.scss
@@ -9,7 +9,6 @@
 	padding: $popup-padding;
 	border-radius: $popup-radius;
 	background-color: $popup-background;
-	box-shadow: $popup-shadow;
 	opacity: 1;
 	transition-property: pre-transform-scale2d, opacity;
 	transition-duration: 0.15s;

--- a/styles/pages/console.scss
+++ b/styles/pages/console.scss
@@ -12,6 +12,7 @@
 		padding-left: 8px;
 		padding-right: 8px;
 		padding-bottom: 8px;
+		box-shadow: 0 0 100px 0 $gray-200;
 	}
 
 	&__inner {

--- a/styles/pages/console.scss
+++ b/styles/pages/console.scss
@@ -6,7 +6,7 @@
 		height: 768px;
 		min-width: 200px; /* Used for resize dragging! */
 		min-height: 200px; /* ditto */
-		background-color: rgba(0, 0, 0, 0.99);
+		background-color: $gray-300;
 		flow-children: down;
 		border-radius: 4px;
 		padding-left: 8px;
@@ -54,6 +54,8 @@
 		margin-left: 8px;
 		horizontal-align: right;
 		vertical-align: bottom;
+		width: 16px;
+		height: 16px;
 	}
 
 	&__header {

--- a/styles/pages/main-menu.scss
+++ b/styles/pages/main-menu.scss
@@ -324,7 +324,7 @@ $drawer-width: 768px;
 
 		#{$root}__button:hover & {
 			opacity: 1;
-			img-shadow: 0 0 24px 2 $blue;
+			img-shadow: 0 0 24px 2 $orange;
 		}
 	}
 

--- a/styles/pages/settings/settings.scss
+++ b/styles/pages/settings/settings.scss
@@ -531,7 +531,7 @@ $page-width: 1920px - $rightnav-width;
 		}
 
 		&--match {
-			color: color.scale($blue, $lightness: 30%);
+			color: color.scale($orange, $lightness: 30%);
 		}
 	}
 
@@ -565,7 +565,7 @@ $page-width: 1920px - $rightnav-width;
 		}
 
 		&--match {
-			color: color.scale($blue, $lightness: 30%);
+			color: color.scale($orange, $lightness: 30%);
 		}
 	}
 }


### PR DESCRIPTION
This pull request mostly changes the colors shown in components, such as the buttons or sliders, to use the P2CE orange color scheme instead of Momentum's.

Changes:
- Changed the color of `$orange` to P2CE's orange color.
- Replaced all instances of the `$blue` color being used for component styling with `$orange`.
- Added box shadows to popups and the console to improve visualization of elevation between layers.
- Made the console background opaque to improve readability of its contents.
- Changed font to Roboto.

![image](https://github.com/StrataSource/p2ce-panorama-ui/assets/48654552/e0232d84-c171-49c6-b691-cdbc6aa75234)
