### PR TITLE
chore: Add tiny build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+npm i
+npm run build


### PR DESCRIPTION
This is for CI/CD integration (on GitLab, not with GitHub actions). If `build.sh` exists, CI/CD will run it, else it does nothing. That way we can support typescript builds and the older JS-only UI.