### PR TITLE
Bigger font size for console and developer text

### DIFF
--- a/styles/config.scss
+++ b/styles/config.scss
@@ -179,6 +179,7 @@ $font-shadows: (
 $font-default-color: $white !default;
 $font-disabled-color: color.scale($font-default-color, $lightness: -20%) !default;
 $font-default-size: 18px !default;
+$font-console-default-size: 14px !default;
 
 $font-primary: 'Roboto' !default;
 $font-secondary: 'Roboto', Arial, sans-serif !default;

--- a/styles/hud/console-notify.scss
+++ b/styles/hud/console-notify.scss
@@ -16,7 +16,7 @@
 		& > MultiselectLabel {
 			text-shadow: 0 2px 3px rgba(0, 0, 0, 1);
 			font-family: $font-monospace;
-			font-size: 11px;
+			font-size: $font-console-default-size;
 		}
 	}
 }

--- a/styles/pages/console.scss
+++ b/styles/pages/console.scss
@@ -24,7 +24,7 @@
 	&__message-target > MultiselectLabel {
 		text-shadow-fast: none;
 		font-family: $font-monospace;
-		font-size: 11px;
+		font-size: $font-console-default-size;
 		margin-right: 16px;
 	}
 


### PR DESCRIPTION
Added an SCSS variable that sets the default font size for in-game console text and console printout (from `developer 1`), and made the default size slightly bigger to accommodate for smaller game windows (i.e. 1280x720)

Fixes issue [#1660](https://github.com/StrataSource/Portal-2-Community-Edition/issues/1660).