### PR TITLE
FIX: Add AlphaAxis to color-picker.xml

### DIFF
--- a/layout/components/color-picker.xml
+++ b/layout/components/color-picker.xml
@@ -21,6 +21,8 @@
 
 		<ColorPickerAxis id="ColorAxis" class="colorpicker__axis" />
 
+		<ColorPickerAlphaAxis id="AlphaAxis" class="colorpicker__axis" />
+
 		<Panel class="colorpicker__right">
 			<Panel class="colorpicker__entry">
 				<Label class="colorpicker__label" text="#ColorPicker_Hue" />


### PR DESCRIPTION
AlphaAxis was missing from color-picker.xml, which means that whenever ConVarColorDisplay is attempted to be used, it will throw an XML error instead, thankfully a 1-line fix. This brings up the file up-to-par with Momentum Mod (although I did notice the Color Picker on P2CE is a bit wacky...)