### PR TITLE
Added Portal Stencil Depth slider & Added Customization Category

### DIFF
--- a/layout/pages/settings/customization.xml
+++ b/layout/pages/settings/customization.xml
@@ -83,6 +83,12 @@
 			<Panel id="GelsSubSection" class="settings-group">
 				<Panel class="settings-group__header">
 					<Label class="settings-group__title" text="#Settings_Gels_Title" tags="gels, customization" />
+
+					<TooltipPanel class="settings-group__reset" tooltip="#Settings_General_Reset">
+						<Button class="button settings-group__reset" onactivate="SettingsShared.resetSettings('GelsSubSection');">
+							<Image class="button__icon" src="file://{images}/reset.svg" />
+						</Button>
+					</TooltipPanel>
 				</Panel>
 
 				<ConVarColorDisplay text="#Settings_Gels_repulsion_color" convar="bounce_paint_color" hasdocspage="false" />

--- a/layout/pages/settings/customization.xml
+++ b/layout/pages/settings/customization.xml
@@ -52,12 +52,12 @@
 					<RadioButton group="portal_dlight" text="#Common_On" value="1" />
 				</SettingsEnum>
 
-				<SettingsSlider
+				<!--<SettingsSlider
 					text="#Settings_Portals_dlight_power"
 					convar=""
 					infomessage="#Settings_Portals_dlight_power_info"
 					hasdocspage="false"
-				/>
+				/>-->
 				<SettingsEnum
 					text="#Settings_Portals_altcolors"
 					convar="cl_portal_alternate_colors"

--- a/layout/pages/settings/customization.xml
+++ b/layout/pages/settings/customization.xml
@@ -14,7 +14,12 @@
                 <Panel class="settings-group__header">
                     <Label class="settings-group__title" text="#Settings_Portal1_Title" tags="menu,ui,portal1" />
                 </Panel>
-                <SettingsEnum text="#Settings_Portal1_xhair" convar="cl_portal_crosshair_mode" infomessage="#Settings_Portal1_xhair_info" hasdocspage="false">
+                <SettingsEnum
+					text="#Settings_Portal1_xhair"
+					convar="cl_portal_crosshair_mode"
+					infomessage="#Settings_Portal1_xhair_info"
+					hasdocspage="false"
+				>
 					<RadioButton group="portal1_crosshair" text="#Settings_Portal1_xhair_p2" value="0" />
 					<RadioButton group="portal1_crosshair" text="#Settings_Portal1_xhair_p1" value="1" />
                 </SettingsEnum>

--- a/layout/pages/settings/customization.xml
+++ b/layout/pages/settings/customization.xml
@@ -15,6 +15,16 @@
                     <Label class="settings-group__title" text="#Settings_Portal1_Title" tags="menu,ui,portal1" />
                 </Panel>
                 <SettingsEnum
+					text="#Settings_Portal1_compat"
+					convar="sv_portal_legacy_compat"
+					infomessage="#Settings_Portal1_compat_info"
+					hasdocspage="false"
+				>
+					<RadioButton group="portal1_compat" text="#Common_Off" value="0" />
+					<RadioButton group="portal1_compat" text="#Common_On" value="1" />
+                </SettingsEnum>
+
+                <SettingsEnum
 					text="#Settings_Portal1_xhair"
 					convar="cl_portal_crosshair_mode"
 					infomessage="#Settings_Portal1_xhair_info"
@@ -24,6 +34,71 @@
 					<RadioButton group="portal1_crosshair" text="#Settings_Portal1_xhair_p1" value="1" />
                 </SettingsEnum>
             </Panel>
+
+			<Panel class="settings-page__spacer" />
+
+			<Panel id="PortalsSubSection" class="settings-group">
+				<Panel class="settings-group__header">
+					<Label class="settings-group__title" text="#Settings_Portals_Title" tags="portals, portal, color, customization" />
+				</Panel>
+
+				<SettingsEnum
+					text="#Settings_Portals_dlight"
+					convar="r_portal_use_dlights"
+					infomessage="#Settings_Portals_dlight_info"
+					hasdocspage="false"
+				>
+					<RadioButton group="portal_dlight" text="#Common_Off" value="0"/>
+					<RadioButton group="portal_dlight" text="#Common_On" value="1"/>
+				</SettingsEnum>
+
+				<SettingsSlider
+					text="#Settings_Portals_dlight_power"
+					convar=""
+					infomessage="#Settings_Portals_dlight_power_info"
+					hasdocspage="false"
+				/>
+				<SettingsEnum
+					text="#Settings_Portals_altcolors"
+					convar="cl_portal_alternate_colors"
+					infomessage="#Settings_Portals_altcolors_info"
+					hasdocspage="false"
+				>
+					<RadioButton group="portal_altcolors" text="#Common_Off" value="0"/>
+					<RadioButton group="portal_altcolors" text="#Common_On" value="1"/>
+				</SettingsEnum>
+
+				<ConVarColorDisplay text="#Settings_Portals_altcolors_primary" convar="cl_portal_sp_primary_color" hasdocspage="false" />
+				<ConVarColorDisplay text="#Settings_Portals_altcolors_secondary" convar="cl_portal_sp_secondary_color" hasdocspage="false" />
+			</Panel>
+
+			<Panel id="GelsSubSection" class="settings-group">
+				<Panel class="settings-group__header">
+					<Label class="settings-group__title" text="#Settings_Gels_Title" tags="gels, customization"/>
+				</Panel>
+
+				<ConVarColorDisplay text="#Settings_Gels_repulsion_color" convar="bounce_paint_color" hasdocspage="false" />
+				<ConVarColorDisplay text="#Settings_Gels_propulsion_color" convar="speed_paint_color" hasdocspage="false" />
+				<ConVarColorDisplay text="#Settings_Gels_conversion_color" convar="portal_paint_color" hasdocspage="false" />
+				<ConVarColorDisplay text="#Settings_Gels_reflection_color" convar="reflect_paint_color" hasdocspage="false" />
+				<ConVarColorDisplay text="#Settings_Gels_adhesion_color" convar="stick_paint_color" hasdocspage="false" />
+			</Panel>
+
+			<Panel id="MiscSubSection" class="settings-group">
+				<Panel class="settings-group__header">
+					<Label class="settings-group__title" text="#Settings_Misc_Title" tags="misc, customization" />
+				</Panel>
+
+				<SettingsEnum
+					text="#Settings_Misc_solenergy_refract"
+					convar="mat_solidenergy_refract"
+					infomessage="#Settings_Misc_solenergy_refract_info"
+					hasdocspage="false"
+				>
+					<RadioButton group="misc_solidenergy" text="#Common_Off" value="0"/>
+					<RadioButton group="misc_solidenergy" text="#Common_On" value="1"/>
+				</SettingsEnum>
+			</Panel>
         </Panel>
     </Panel>
 </root>

--- a/layout/pages/settings/customization.xml
+++ b/layout/pages/settings/customization.xml
@@ -48,8 +48,8 @@
 					infomessage="#Settings_Portals_dlight_info"
 					hasdocspage="false"
 				>
-					<RadioButton group="portal_dlight" text="#Common_Off" value="0"/>
-					<RadioButton group="portal_dlight" text="#Common_On" value="1"/>
+					<RadioButton group="portal_dlight" text="#Common_Off" value="0" />
+					<RadioButton group="portal_dlight" text="#Common_On" value="1" />
 				</SettingsEnum>
 
 				<SettingsSlider
@@ -64,17 +64,25 @@
 					infomessage="#Settings_Portals_altcolors_info"
 					hasdocspage="false"
 				>
-					<RadioButton group="portal_altcolors" text="#Common_Off" value="0"/>
-					<RadioButton group="portal_altcolors" text="#Common_On" value="1"/>
+					<RadioButton group="portal_altcolors" text="#Common_Off" value="0" />
+					<RadioButton group="portal_altcolors" text="#Common_On" value="1" />
 				</SettingsEnum>
 
-				<ConVarColorDisplay text="#Settings_Portals_altcolors_primary" convar="cl_portal_sp_primary_color" hasdocspage="false" />
-				<ConVarColorDisplay text="#Settings_Portals_altcolors_secondary" convar="cl_portal_sp_secondary_color" hasdocspage="false" />
+				<ConVarColorDisplay
+					text="#Settings_Portals_altcolors_primary"
+					convar="cl_portal_sp_primary_color"
+					hasdocspage="false"
+				/>
+				<ConVarColorDisplay
+					text="#Settings_Portals_altcolors_secondary"
+					convar="cl_portal_sp_secondary_color"
+					hasdocspage="false"
+				/>
 			</Panel>
 
 			<Panel id="GelsSubSection" class="settings-group">
 				<Panel class="settings-group__header">
-					<Label class="settings-group__title" text="#Settings_Gels_Title" tags="gels, customization"/>
+					<Label class="settings-group__title" text="#Settings_Gels_Title" tags="gels, customization" />
 				</Panel>
 
 				<ConVarColorDisplay text="#Settings_Gels_repulsion_color" convar="bounce_paint_color" hasdocspage="false" />
@@ -95,8 +103,8 @@
 					infomessage="#Settings_Misc_solenergy_refract_info"
 					hasdocspage="false"
 				>
-					<RadioButton group="misc_solidenergy" text="#Common_Off" value="0"/>
-					<RadioButton group="misc_solidenergy" text="#Common_On" value="1"/>
+					<RadioButton group="misc_solidenergy" text="#Common_Off" value="0" />
+					<RadioButton group="misc_solidenergy" text="#Common_On" value="1" />
 				</SettingsEnum>
 			</Panel>
         </Panel>

--- a/layout/pages/settings/customization.xml
+++ b/layout/pages/settings/customization.xml
@@ -1,0 +1,27 @@
+<root>
+	<styles>
+		<include src="file://{resources}/styles/main.scss" />
+	</styles>
+	<scripts>
+		<include src="file://{scripts}/pages/settings/page.js" />
+		<!-- Temporary -->
+		<include src="file://{scripts}/util/dosa.ts" />
+	</scripts>
+
+    <Panel class="settings-page">
+        <Panel id="SettingsPageContainer" class="settings-page__container">
+            <Panel id="Portal1SubSection" class="settings-group">
+                <Panel class="settings-group__header">
+                    <Label class="settings-group__title" text="#Settings_Portal1_Title" tags="menu,ui,portal1" />
+
+
+                </Panel>
+
+                <SettingsEnum text="#Settings_Portal1_xhair" convar="cl_portal_crosshair_mode" infomessage="#Settings_Portal1_xhair_info" hasdocspage="false">
+					<RadioButton group="portal1_crosshair" text="#Settings_Portal1_xhair_p2" value="0" />
+					<RadioButton group="portal1_crosshair" text="#Settings_Portal1_xhair_p1" value="1" />
+                </SettingsEnum>
+            </Panel>
+        </Panel>
+    </Panel>
+</root>

--- a/layout/pages/settings/customization.xml
+++ b/layout/pages/settings/customization.xml
@@ -13,10 +13,7 @@
             <Panel id="Portal1SubSection" class="settings-group">
                 <Panel class="settings-group__header">
                     <Label class="settings-group__title" text="#Settings_Portal1_Title" tags="menu,ui,portal1" />
-
-
                 </Panel>
-
                 <SettingsEnum text="#Settings_Portal1_xhair" convar="cl_portal_crosshair_mode" infomessage="#Settings_Portal1_xhair_info" hasdocspage="false">
 					<RadioButton group="portal1_crosshair" text="#Settings_Portal1_xhair_p2" value="0" />
 					<RadioButton group="portal1_crosshair" text="#Settings_Portal1_xhair_p1" value="1" />

--- a/layout/pages/settings/settings.xml
+++ b/layout/pages/settings/settings.xml
@@ -223,6 +223,30 @@
 								>
 									<Label class="settings-nav__subitem-label" text="#Settings_Portal1_Title" />
 								</RadioButton>
+								<RadioButton
+									id="PortalsRadio"
+									class="settings-nav__subitem"
+									group="SettingsSubNav"
+									onactivate="MainMenuSettings.navigateToSubsection('CustomizationSettings', 'PortalsSubSection')"
+								>
+									<Label class="settings-nav__subitem-label" text="#Settings_Portals_Title" />
+								</RadioButton>
+								<RadioButton
+									id="GelsRadio"
+									class="settings-nav__subitem"
+									group="SettingsSubNav"
+									onactivate="MainMenuSettings.navigateToSubsection('CustomizationSettings', 'GelsSubSection')"
+								>
+									<Label class="settings-nav__subitem-label" text="#Settings_Gels_Title" />
+								</RadioButton>
+								<RadioButton
+									id="MiscRadio"
+									class="settings-nav__subitem"
+									group="SettingsSubNav"
+									onactivate="MainMenuSettings.navigateToSubsection('CustomizationSettings', 'MiscSubSection')"
+								>
+									<Label class="settings-nav__subitem-label" text="#Settings_Misc_Title" />
+								</RadioButton>
 							</Panel>
 						</RadioButton>
 

--- a/layout/pages/settings/settings.xml
+++ b/layout/pages/settings/settings.xml
@@ -202,6 +202,30 @@
 
 						</RadioButton>
 
+						<Panel class="settings-nav__separator" />
+
+						<!-- CUSTOMIZATION -->
+
+						<RadioButton
+							id="CustomizationRadio"
+							class="settings-nav__item"
+							group="SettingsNav"
+							onactivate="MainMenuSettings.navigateToTab('CustomizationSettings')"
+						>
+							<Label class="settings-nav__item-label" text="#Settings_Customization" />
+
+							<Panel class="settings-nav__subsection settings-nav__subsection--11 settings-nav__subsection--hidden">
+								<RadioButton
+									id="Portal1Radio"
+									class="settings-nav__subitem"
+									group="SettingsSubNav"
+									onactivate="MainMenuSettings.navigateToSubsection('CustomizationSettings', 'Portal1SubSection')"
+								>
+									<Label class="settings-nav__subitem-label" text="#Settings_Portal1_Title" />
+								</RadioButton>
+							</Panel>
+						</RadioButton>
+
 					</Panel>
 
 				</Panel>

--- a/layout/pages/settings/video.xml
+++ b/layout/pages/settings/video.xml
@@ -134,6 +134,16 @@
 					<Label text="#Settings_General_Enabled" value="1" id="laptoppower1" />
 				</SettingsEnumDropDown>
 
+				<SettingsSlider
+					text="#Settings_Video_PStencilDepth"
+					convar="r_portal_stencil_depth"
+					id="PStencilDepth"
+					infomessage="#Settings_Video_PStencilDepth_Info"
+					min="0"
+					max="8"
+				>
+				</SettingsSlider>
+
 				<SettingsEnumDropDown
 					text="#Settings_Video_PreventThreadSleep"
 					onuserinputsubmit="SettingsShared.videoSettingsOnUserInputSubmit()"

--- a/scripts/common/settings.js
+++ b/scripts/common/settings.js
@@ -39,7 +39,7 @@ const SettingsTabs = {
 		children: {
 			Portal1SubSection: 'Portal1Radio',
 			PortalsSubSection: 'PortalsRadio',
-			GelsSubSection:	'GelsRadio',
+			GelsSubSection: 'GelsRadio',
 			MiscSubSection: 'MiscRadio'
 		}
 	},

--- a/scripts/common/settings.js
+++ b/scripts/common/settings.js
@@ -37,7 +37,10 @@ const SettingsTabs = {
 		xml: 'customization',
 		radioid: 'CustomizationRadio',
 		children: {
-			Portal1SubSection: 'Portal1Radio'
+			Portal1SubSection: 'Portal1Radio',
+			PortalsSubSection: 'PortalsRadio',
+			GelsSubSection:	'GelsRadio',
+			MiscSubSection: 'MiscRadio'
 		}
 	},
 	SearchSettings: {

--- a/scripts/common/settings.js
+++ b/scripts/common/settings.js
@@ -33,6 +33,13 @@ const SettingsTabs = {
 			UISubSection: 'UIRadio'
 		}
 	},
+	CustomizationSettings: {
+		xml: 'customization',
+		radioid: 'CustomizationRadio',
+		children: {
+			Portal1SubSection: 'Portal1Radio'
+		}
+	},
 	SearchSettings: {
 		xml: 'search'
 	}


### PR DESCRIPTION
As the title suggests, added the Portal Dencil Depth slider to Video Settings, added a Customization category with a Portal 1 features SubSection that currently only adds the crosshair option (Should probably be part of a bigger SubSection). This is in relation to #33 as these settings in particular haven't been implemented yet. I limited the Portal Dencil Depth slider arbitrarily to a value of 8 as to not destroy computers.