### PR TITLE
Fix crash in Audio Settings when scrolling

### DIFF
--- a/scripts/pages/settings/settings.js
+++ b/scripts/pages/settings/settings.js
@@ -203,7 +203,10 @@ class MainMenuSettings {
 						(child.actualyoffset + child.actuallayoutheight + this.spacerHeight) / containerHeight) ||
 				scrollOffset === 0
 			) {
-				this.panels.nav.FindChildTraverse(SettingsTabs[tab].children[child.id]).checked = true;
+				const navChild = this.panels.nav.FindChildTraverse(SettingsTabs[tab].children[child.id]);
+                if (navChild) {
+                    navChild.checked = true;
+                }
 				break;
 			}
 		}


### PR DESCRIPTION
### Summary
This PR fixes a crash that occurs when scrolling through the Audio Settings page. The issue was caused by the onPageScrolled method attempting to access the --checked-- property on a null object, leading to a runtime exception.

### Root Cause
When the user scrolls quickly or navigates away from the Audio Settings page mid-scroll, the view reference used in onPageScrolled may become null. The method did not account for this possibility, resulting in a crash.

### Fix
Added a null check before accessing the property in onPageScrolled to ensure the object is valid.

### Steps to Reproduce
- Open Settings > Audio
- Scroll up/down rapidly
- The app crashes due to a NullPointerException in onPageScrolled

### Testing
- Verified that scrolling no longer causes a crash
- Confirmed that Audio Settings UI behaves as expected after the fi
