### PR TITLE
fix: incorrect snd volume weapon cvar binding in audio settings

### DIFF
--- a/layout/pages/settings/audio.xml
+++ b/layout/pages/settings/audio.xml
@@ -75,7 +75,7 @@
 					min="0"
 					max="1"
 					percentage="true"
-					convar="snd_volume_weapon_player"
+					convar="snd_volume_weapon_localplayer"
 					tags="weapon"
 					hasdocspage="false"
 				/>
@@ -85,7 +85,7 @@
 					min="0"
 					max="1"
 					percentage="true"
-					convar="snd_volume_weapon_overall"
+					convar="snd_volume_weapon"
 					tags="overall"
 					hasdocspage="false"
 				/>


### PR DESCRIPTION
Fixes weapon audio sliders being bound to the incorrect (missing) convars:
`snd_volume_weapon_player` -> `snd_volume_weapon_localplayer`
`snd_volume_weapon_overall` -> `snd_volume_weapon`

All sliders now function as expected, but some sounds may not be bound to their appropriate categorical cvar. From basic testing, portalgun weapon sounds are affected by `snd_volume_weapon`. The impact sounds are not bound to any of the weapon volume cvars.

Addresses StrataSource/Portal-2-Community-Edition#1983