### PR TITLE
Convert snd_mute_losefocus to a slider

### DIFF
--- a/layout/pages/settings/audio.xml
+++ b/layout/pages/settings/audio.xml
@@ -135,6 +135,17 @@
 					hasdocspage="false"
 				/>
 
+				<SettingsSlider
+					text="#Settings_Volume_Background"
+					infomessage="#Settings_Volume_Background_info"
+					min="0"
+					max="1"
+					invert="true"
+					percentage="true"
+					convar="snd_mute_losefocus"
+					hasdocspage="false"
+				/>
+
 			</Panel>
 
 			<Panel class="settings-page__spacer" />
@@ -248,16 +259,6 @@
 					<Label id="device7" text="XXXXXX 7" />
 					<Label id="device8" text="XXXXXX 8" />
 				</SettingsEnumDropDown>
-
-				<SettingsSlider
-					text="#Settings_AudioDevices_Background"
-					infomessage="#Settings_AudioDevices_Background_info"
-					min="0"
-					max="1"
-					percentage="true"
-					convar="snd_mute_losefocus"
-					hasdocspage="false"
-				/>
 
 			</Panel>
 

--- a/localization/panorama_english.txt
+++ b/localization/panorama_english.txt
@@ -519,6 +519,8 @@
 		"Settings_Volume_PlayerWeapon_info"					"Sets volume for the player's combat interactions."
 		"Settings_Volume_OverallWeapon"						"Overall Weapon Volume"
 		"Settings_Volume_OverallWeapon_info"				"Sets volume for all combat interactions in the world."
+		"Settings_Volume_Background"						"Unfocused Volume"
+		"Settings_Volume_Background_info"					"Sets the overall volume of the game while the window is out of focus."
 		
 		"Settings_ClosedCaptions_Title"						"Closed Captions and Subtitles"
 		"Settings_ClosedCaptions_Enable"					"Closed Captions"
@@ -536,8 +538,6 @@
 		// "Settings_AudioDevices_Speaker_71"				"7.1 Surround Sound"	// Unsupported by CSGO and Strata?
 		"Settings_AudioDevices_Speaker"						"Audio Output Configuration"
 		"Settings_AudioDevices_Speaker_info"				"Alters audio playback behavior by allocating specific sound channels to individual speakers based on a specific device configuration."
-		"Settings_AudioDevices_Background"					"Lower volume while unfocused"
-		"Settings_AudioDevices_Background_info"				"Determines how much the game should reduce the volume of audio while in the background."
 		
 		// Settings - Video
 		"Settings_Video"								"Video"


### PR DESCRIPTION
`snd_mute_losefocus` in Strata can be set to a fractional value to partially lower the volume of the audio when the window is out of focus, but this wasn't being exposed in the UI. (Revo forgot about this too...) This PR simply converts it to a slider.

Note that the way this is exposed is a bit weird, as dragging the slider to the *right* makes the volume *lower* - I wanted to make it the other way around (and label it "unfocused volume"), but reversing the slider's min/max values caused it to bug out and I couldn't find any files pertaining to slider functionality, so it might require a C++ code change.