### PR TITLE
feat(hud): add center print panel for env_message display

### DIFF
--- a/layout/hud/center-print.xml
+++ b/layout/hud/center-print.xml
@@ -1,0 +1,13 @@
+<root>
+	<styles>
+		<include src="file://{resources}/styles/main.scss" />
+	</styles>
+	<scripts>
+		<include src="file://{scripts}/hud/center-print.ts" />
+	</scripts>
+	<Panel class="center-print" hittest="false">
+		<Panel id="CenterPrint" class="center-print__container">
+			<Label id="CenterPrintLabel" class="center-print__label" html="true" />
+		</Panel>
+	</Panel>
+</root>

--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -12,6 +12,7 @@
 
 		<!-- Center of screen HUD laid out vertically top-to-bottom -->
 		<Panel id="HudCenter" hittest="false" hittestchildren="false">
+			<Frame src="file://{resources}/layout/hud/center-print.xml" />
 		</Panel>
 
 		<!-- HUD anchored to top-left corner of screen, laid out vertically top-to-bottom -->

--- a/scripts/hud/center-print.ts
+++ b/scripts/hud/center-print.ts
@@ -1,0 +1,57 @@
+'use strict';
+
+class CenterPrint {
+	static readonly HOLD_TIME = 5;
+	static readonly FADE_TIME = 1.5;
+
+	static hideSchedule: number | null = null;
+	static panel: Panel;
+	static label: Label;
+
+	static onShowCenterPrintText(message: string, _priority: unknown) {
+		try {
+			CenterPrint.cancelPending();
+
+			const token = '#' + message;
+			const localized = $.Localize(token);
+			CenterPrint.label.text =
+				localized && localized !== token ? localized : message;
+			CenterPrint.panel.RemoveClass('center-print--hidden');
+			CenterPrint.panel.AddClass('center-print--visible');
+
+			CenterPrint.hideSchedule = $.Schedule(
+				CenterPrint.HOLD_TIME,
+				CenterPrint.hide
+			);
+		} catch (e) {
+			$.Warning('CenterPrint error: ' + e);
+		}
+	}
+
+	static hide() {
+		CenterPrint.hideSchedule = null;
+		CenterPrint.panel.RemoveClass('center-print--visible');
+		CenterPrint.panel.AddClass('center-print--hidden');
+	}
+
+	static cancelPending() {
+		if (CenterPrint.hideSchedule !== null) {
+			try {
+				$.CancelScheduled(CenterPrint.hideSchedule as any);
+			} catch (e) {
+				// Ignore
+			}
+			CenterPrint.hideSchedule = null;
+		}
+	}
+
+	static {
+		CenterPrint.panel = $('#CenterPrint') as Panel;
+		CenterPrint.label = $('#CenterPrintLabel') as Label;
+
+		$.RegisterForUnhandledEvent(
+			'ShowCenterPrintText',
+			CenterPrint.onShowCenterPrintText
+		);
+	}
+}

--- a/scripts/hud/center-print.ts
+++ b/scripts/hud/center-print.ts
@@ -4,7 +4,7 @@ class CenterPrint {
 	static readonly HOLD_TIME = 5;
 	static readonly FADE_TIME = 1.5;
 
-	static hideSchedule: number | null = null;
+	static hideSchedule: uuid | null = null;
 	static panel: Panel;
 	static label: Label;
 
@@ -33,7 +33,7 @@ class CenterPrint {
 	static cancelPending() {
 		if (CenterPrint.hideSchedule !== null) {
 			try {
-				$.CancelScheduled(CenterPrint.hideSchedule as any);
+				$.CancelScheduled(CenterPrint.hideSchedule);
 			} catch (e) {
 				// Ignore
 			}

--- a/scripts/hud/center-print.ts
+++ b/scripts/hud/center-print.ts
@@ -14,15 +14,11 @@ class CenterPrint {
 
 			const token = '#' + message;
 			const localized = $.Localize(token);
-			CenterPrint.label.text =
-				localized && localized !== token ? localized : message;
+			CenterPrint.label.text = localized && localized !== token ? localized : message;
 			CenterPrint.panel.RemoveClass('center-print--hidden');
 			CenterPrint.panel.AddClass('center-print--visible');
 
-			CenterPrint.hideSchedule = $.Schedule(
-				CenterPrint.HOLD_TIME,
-				CenterPrint.hide
-			);
+			CenterPrint.hideSchedule = $.Schedule(CenterPrint.HOLD_TIME, CenterPrint.hide);
 		} catch (e) {
 			$.Warning('CenterPrint error: ' + e);
 		}
@@ -49,9 +45,6 @@ class CenterPrint {
 		CenterPrint.panel = $('#CenterPrint') as Panel;
 		CenterPrint.label = $('#CenterPrintLabel') as Label;
 
-		$.RegisterForUnhandledEvent(
-			'ShowCenterPrintText',
-			CenterPrint.onShowCenterPrintText
-		);
+		$.RegisterForUnhandledEvent('ShowCenterPrintText', CenterPrint.onShowCenterPrintText);
 	}
 }

--- a/styles/hud/_index.scss
+++ b/styles/hud/_index.scss
@@ -1,5 +1,6 @@
 @use 'ammo';
 @use 'bone-counts';
+@use 'center-print';
 @use 'console-notify';
 @use 'health';
 @use 'hud';

--- a/styles/hud/center-print.scss
+++ b/styles/hud/center-print.scss
@@ -1,0 +1,34 @@
+@use '../config' as *;
+
+.center-print {
+	horizontal-align: center;
+	vertical-align: center;
+	width: 100%;
+
+	&__container {
+		horizontal-align: center;
+		opacity: 0;
+		transition-property: opacity;
+		transition-duration: 1.5s;
+		transition-timing-function: ease-in-out;
+	}
+
+	&__container.center-print--visible {
+		opacity: 1;
+		transition-duration: 0.5s;
+	}
+
+	&__container.center-print--hidden {
+		opacity: 0;
+		transition-duration: 1.5s;
+	}
+
+	&__label {
+		horizontal-align: center;
+		color: $white;
+		font-size: 28px;
+		font-weight: medium;
+		text-align: center;
+		text-shadow-fast: 2px 2px 4px $dark-300;
+	}
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                    

Adds a Panorama HUD panel that handles `ShowCenterPrintText` events, providing  visual display for `env_message` and `game_text` entities.

Currently, `env_message` entities fire `ShowCenterPrintText` but nothing in the Panorama UI listens for it, so the text is silently discarded. This adds the missing panel.

  ### Behavior
  - Listens for `ShowCenterPrintText` events
  - Attempts localization via `$.Localize('#' + message)`, falls back to raw text
  - Fades in (0.5s), holds for 5s, fades out (1.5s)
  - Subsequent messages reset the timer
  - Supports HTML via `html="true"` on the label

  ### Files
  - **New:** `layout/hud/center-print.xml`, `scripts/hud/center-print.ts`, `styles/hud/center-print.scss`
  - **Modified:** `layout/hud/hud.xml` (Frame in HudCenter), `styles/hud/_index.scss` (import)