### PR TITLE
Main menu alignment fix for ultrawide

### DIFF
--- a/styles/pages/main-menu/main-menu.scss
+++ b/styles/pages/main-menu/main-menu.scss
@@ -138,7 +138,7 @@ $pane-move-time: 0.1s;
 		height: 100%;
 		max-width: 1920px;
 		max-height: 1080px;
-		align: center center;
+		align: left center;
 
 		&__t-prop {
 			transition:


### PR DESCRIPTION
Currently the main menu UI is aligned to the center. On 16:9 this looks correct while on ultrawide, it obviously doesn't.
No noticeable difference on 16:9

Before:

16:9
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/69be711b-5169-4633-b832-917f9f8c34fd" />

21:9 (Ultrawide)
<img width="3432" height="1409" alt="image" src="https://github.com/user-attachments/assets/21200281-de35-4e37-929b-4878f5117950" />

After:

16:9
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6f2c2637-9747-4fbc-abe7-ba5dce76eb9f" />

21:9 (Ultrawide)
<img width="3432" height="1409" alt="image" src="https://github.com/user-attachments/assets/113536cf-eb56-4ace-a304-febadd25d53c" />
