### PR TITLE
Remove invalid settings

### DIFF
--- a/layout/pages/settings/video.xml
+++ b/layout/pages/settings/video.xml
@@ -237,31 +237,6 @@
 				</SettingsEnumDropDown>
 
 				<SettingsEnumDropDown
-					text="#Settings_Render_EffectDetail"
-					onuserinputsubmit="SettingsShared.videoSettingsOnUserInputSubmit()"
-					id="EffectDetail"
-					infomessage="#Settings_Render_EffectDetail_Info"
-				>
-					<Label text="#Settings_General_Low" value="0" id="cpulevel0" />
-					<Label text="#Settings_General_Medium" value="1" id="cpulevel1" />
-					<Label text="#Settings_General_High" value="2" id="cpulevel2" />
-					<Label text="#Settings_General_Autodetect" value="9999999" id="cpulevel3" />
-				</SettingsEnumDropDown>
-
-				<SettingsEnumDropDown
-					text="#Settings_Render_ShaderDetail"
-					onuserinputsubmit="SettingsShared.videoSettingsOnUserInputSubmit()"
-					id="ShaderDetail"
-					infomessage="#Settings_Render_ShaderDetail_Info"
-				>
-					<Label text="#Settings_General_Low" value="0" id="gpulevel0" />
-					<Label text="#Settings_General_Medium" value="1" id="gpulevel1" />
-					<Label text="#Settings_General_High" value="2" id="gpulevel2" />
-					<Label text="#Settings_General_VeryHigh" value="3" id="gpulevel3" />
-					<Label text="#Settings_General_Autodetect" value="9999999" id="gpulevel4" />
-				</SettingsEnumDropDown>
-
-				<SettingsEnumDropDown
 					text="#Settings_Render_Multicore"
 					onuserinputsubmit="SettingsShared.videoSettingsOnUserInputSubmit()"
 					id="MatQueueMode"

--- a/styles/pages/main-menu/main-menu.scss
+++ b/styles/pages/main-menu/main-menu.scss
@@ -138,7 +138,7 @@ $pane-move-time: 0.1s;
 		height: 100%;
 		max-width: 1920px;
 		max-height: 1080px;
-		align: center center;
+		align: left center;
 
 		&__t-prop {
 			transition:


### PR DESCRIPTION
Effect detail and shader detail settings don't work and aren't saved, so they should be removed from the settings page