### PR TITLE
fix: misc logic bugs and fragile string handling

### DIFF
--- a/scripts/pages/campaigns/campaign-saves.ts
+++ b/scripts/pages/campaigns/campaign-saves.ts
@@ -90,7 +90,8 @@ class SaveEntry {
 							() => {
 								// TODO: Replace this with other save API
 								const savFile: string = this.save.fileName;
-								SaveRestoreAPI.SaveGame(savFile.substring(0, savFile.length - 4));
+								const nameWithoutExt = savFile.endsWith('.sav') ? savFile.slice(0, -4) : savFile;
+								SaveRestoreAPI.SaveGame(nameWithoutExt);
 
 								CampaignSaves.purgeSaveList();
 
@@ -119,7 +120,8 @@ class SaveEntry {
 					() => {
 						// TODO: Replace this with other save API
 						const savFile: string = this.save.fileName;
-						SaveRestoreAPI.DeleteSave(savFile.substring(0, savFile.length - 4));
+						const nameWithoutExt = savFile.endsWith('.sav') ? savFile.slice(0, -4) : savFile;
+						SaveRestoreAPI.DeleteSave(nameWithoutExt);
 
 						CampaignSaves.purgeSaveList();
 

--- a/scripts/pages/main-menu/addons.ts
+++ b/scripts/pages/main-menu/addons.ts
@@ -507,7 +507,15 @@ class MountManager {
 			return;
 		}
 
-		const response = JSON.parse(data.responseText.substring(0, data.responseText.length - 1));
+		// Updated this (same line in news.ts) to be safer.
+		let response;
+		try {
+			response = JSON.parse(data.responseText.trim());
+		} catch (e) {
+			console.error('Falling back to less safe method. Error:', e);
+			response = JSON.parse(data.responseText.substring(0, data.responseText.length - 1));
+		}
+
 		const appId = Object.keys(response)[0];
 		const appInfo = response[Object.keys(response)[0]]['data'];
 

--- a/scripts/pages/main-menu/menu-manager.ts
+++ b/scripts/pages/main-menu/menu-manager.ts
@@ -170,7 +170,7 @@ class MenuManager {
 						rightDate.setFullYear(date.getFullYear());
 						if (WorkshopAPI.IsWorkshopToolsMode()) {
 							logo = 'file://{images}/logo_sdk.svg';
-						} else if (date.getMonth() === rightDate.getMonth() && date.getDay() === rightDate.getDay()) {
+						} else if (date.getMonth() === rightDate.getMonth() && date.getDate() === rightDate.getDate()) {
 							logo = 'file://{images}/the_objectively_better_logo.png';
 						}
 					}

--- a/scripts/pages/main-menu/news.ts
+++ b/scripts/pages/main-menu/news.ts
@@ -76,7 +76,15 @@ class NewsReel {
 
 		// using the responseText on its own results in a parsing error
 		// might be some invisible terminating character or something
-		const response = JSON.parse(data.responseText.substring(0, data.responseText.length - 1));
+		// Updated with try/catch to make it safer ^^^
+		let response;
+		try {
+			response = JSON.parse(data.responseText.trim());
+		} catch (e) {
+			console.error('Falling back to less safe method. Error:', e);
+			response = JSON.parse(data.responseText.substring(0, data.responseText.length - 1));
+		}
+
 		const allNews = response['appnews']['newsitems'];
 
 		for (let i = 0; i < this.NEWS_COUNT; ++i) {

--- a/scripts/pages/settings/page.js
+++ b/scripts/pages/settings/page.js
@@ -130,8 +130,7 @@ class SettingsShared {
 		findCvarsRecursive(section);
 
 		let cvarParams = '';
-		for (const [i, cvar] in cvars.entries())
-			cvarParams += (index !== 0 ? '&' : '') + 'cvar' + (index + 1) + '=' + cvar;
+		for (const [i, cvar] of cvars.entries()) cvarParams += (i !== 0 ? '&' : '') + 'cvar' + (i + 1) + '=' + cvar;
 
 		UiToolkitAPI.ShowCustomLayoutPopupParameters(
 			'',


### PR DESCRIPTION
Small bugs:
* Fix for...in --> for...of and renamed `index` --> `i` in the loop (cvar query string was built incorrectly)
* Fix April Fools logo check using `getDay()` (which returns the day of week) instead of `getDate()` (day of month) so it triggers on April 1st as intended now
* Replace hardcoded `substring(0, length - 1)` with `.trim()` when parsing API responses in `addons.ts` and `news.ts` to make it more robust (still falls back to old method if the new one fails)
* Add `.endsWith('.sav')` guard before stripping the file extension in `campaign-saves.ts` to prevent silent data loss in case a filename doesn't match the assumed format.