### PR TITLE
Add support for multiple plurals to search results for Cyrillic languages

### DIFF
--- a/localization/panorama_english.txt
+++ b/localization/panorama_english.txt
@@ -501,6 +501,12 @@
 		"Settings_General_Search_MatchedEnglishTag"		"Matches "
 		"Settings_General_Search_VeryFull"				"{s:count} more match"
 		"Settings_General_Search_VeryFull_Plural"		"{s:count} more matches"
+
+		// Needed for Cyrillic languages. Russian has two definitions of the word "plural"; one is for
+		// exactly two matches (Search_VeryFull_Plural), another is for more than two matches (Search_VeryFull_Plural2).
+		// So this "duplicate" string exists and is used in place.
+		"Settings_General_Search_VeryFull_Plural2"		"{s:count} more matches"
+		
 		"Settings_Reset_Title"							"Confirm Reset"
 		"Settings_Reset_Message_Generic"				"Are you sure you want to reset this section's settings to their default values?"
 		"Settings_Reset_Message_Checker"				"The following settings are currently different from their default values and will be reset:"

--- a/scripts/pages/settings/search.js
+++ b/scripts/pages/settings/search.js
@@ -212,6 +212,10 @@ class SettingsSearch {
 					class: 'settings-search__empty-para'
 				});
 				if (left === 1) p.SetLocalizationString('#Settings_General_Search_VeryFull');
+				// Needed for Cyrillic languages. Russian has two definitions of the word "plural"; one is for
+				// exactly two matches (Search_VeryFull_Plural), another is for more than two matches (Search_VeryFull_Plural2).
+				// So this "duplicate" string exists and is used in place.
+				else if (left > 2) p.SetLocalizationString('#Settings_General_Search_VeryFull_Plural2');
 				else p.SetLocalizationString('#Settings_General_Search_VeryFull_Plural');
 				p.SetDialogVariable('count', left);
 			}


### PR DESCRIPTION
Requested by @Laveig.

This basically does what it says on the tin. Russian has two definitions of the word "plural", and the current version of search in P2:CE doesn't actually account for this:

<img width="923" height="178" alt="btw @pivotman319 there are two plurals in russian language, one for less than 5 objects and one for 5 and more objects so I need an additional plural token for Settings_General_Search_VeryFull for the text to be correct. example: 1 match - 1 совпадение; 2 matches - 2 совпадения; 6 matches - 6 совпадений." src="https://github.com/user-attachments/assets/b30c0a52-fbd6-4a30-a71d-3f55bbf2aba5" />

This PR addresses that by adding a second loc string - one is for exactly two matches (`#Settings_General_Search_VeryFull_Plural`), another is for more than two matches (`#Settings_General_Search_VeryFull_Plural2`) - the latter "duplicate" string exists and is used in place. This shouldn't be visible to the end-user on languages that don't have multiple plural terms.

<img width="1920" height="1080" alt="One match" src="https://github.com/user-attachments/assets/a1c0f4e9-b8cf-4fb6-b214-8de73084f7fc" />
<img width="1920" height="1080" alt="Two matches" src="https://github.com/user-attachments/assets/1c09c15a-8952-43ee-a561-c235379f1a89" />
<img width="1920" height="1080" alt="Three matches (placeholder suffix for demo purposes, not in actual PR)" src="https://github.com/user-attachments/assets/bf37de19-d102-482a-9319-11b1efc519be" />

