### PR TITLE
remove tonemapping, color correction, and bloom settings

### DIFF
--- a/layout/pages/settings/video.xml
+++ b/layout/pages/settings/video.xml
@@ -288,36 +288,6 @@
 					<Label text="#Settings_General_Disabled" value="0" id="motionblur0" />
 					<Label text="#Settings_General_Enabled" value="1" id="motionblur1" />
 				</SettingsEnumDropDown>
-
-				<SettingsEnumDropDown
-					text="#Settings_Render_DynamicTonemapping"
-					onuserinputsubmit="SettingsShared.videoSettingsOnUserInputSubmit()"
-					id="DynamicTonemapping"
-					infomessage="#Settings_Render_DynamicTonemapping_Info"
-				>
-					<Label text="#Settings_General_Disabled" value="0" id="dynamictonemapping0" />
-					<Label text="#Settings_General_Enabled" value="1" id="dynamictonemapping1" />
-				</SettingsEnumDropDown>
-
-				<SettingsEnumDropDown
-					text="#Settings_Render_Bloom"
-					onuserinputsubmit="SettingsShared.videoSettingsOnUserInputSubmit()"
-					id="DisableBloom"
-					infomessage="#Settings_Render_Bloom_Info"
-				>
-					<Label text="#Settings_General_Disabled" value="1" id="disablebloom0" />
-					<Label text="#Settings_General_Enabled" value="0" id="disablebloom1" />
-				</SettingsEnumDropDown>
-
-				<SettingsEnumDropDown
-					text="#Settings_Render_ColorCorrection"
-					onuserinputsubmit="SettingsShared.videoSettingsOnUserInputSubmit()"
-					id="ColorCorrection"
-					infomessage="#Settings_Render_ColorCorrection_Info"
-				>
-					<Label text="#Settings_General_Disabled" value="0" id="colorcorrection0" />
-					<Label text="#Settings_General_Enabled" value="1" id="colorcorrection1" />
-				</SettingsEnumDropDown>
 			</Panel>
 
 			<Panel class="settings-page__spacer" />

--- a/localization/panorama_english.txt
+++ b/localization/panorama_english.txt
@@ -635,15 +635,6 @@
 
 		"Settings_Render_FXAA" 							"Fast Approximate Anti-Aliasing (FXAA)"
 		"Settings_Render_FXAA_Info"						"Anti-aliasing provides a smooth appearance at the edges of geometry, eliminating jagged edges. Enabling FXAA can degrade graphics performance."
-		
-		"Settings_Render_Bloom"							"Bloom"
-		"Settings_Render_Bloom_Info"					"HDR Bloom is the &quot;halo&quot; effect seen on very bright objects or the environment in general. This has no impact on graphics performance."
-
-		"Settings_Render_DynamicTonemapping"			"HDR Tonemapping"
-		"Settings_Render_DynamicTonemapping_Info"		"HDR tonemapping is the dynamic increase or decrease of exposure of the screen depending on the displayed content. This has no impact on graphics performance."
-
-		"Settings_Render_ColorCorrection"				"Color Correction"
-		"Settings_Render_ColorCorrection_Info"			"Color Correction is used in some maps to alter the color balance to achieve a certain aesthetic tone. This has no impact on graphics performance."
 
 		"Settings_Render_Multicore"						"Multicore Rendering"
 		"Settings_Render_Multicore_Info"				"Multicore rendering allows Portal 2: Community Edition to split rendering across multiple CPU and GPU cores present on your system. The Disabled setting may negatively impact overall framerate and visual quality."


### PR DESCRIPTION
We're going back in StrataSource to the p2ce-panorama-ui to get tonemapping OFF. THE. MENU.

i'm not entirely sure if this would need internal code changes as well, this is my first time doing panorama stuff.

the reasoning  behind this is that disabling tonemapping, color correction, and bloom only serves to hinder a maps intended visuals, and doesn't affect performance in any notable way. two immediate examples of campaigns drastically affected by the removal of tonemapping/colorcorrection are the Portal 2 campaign, which uses high autoexposure values in combination with dark lighting, and the HL2 Episodes, which make heavy use of tonemapping for realistic outdoor lighting and color correction for scripted sequences. 

i'm not entirely sure if this would need internal code changes as well, this is my first time doing panorama stuff

for a visual example, here's sp_a2_triple_laser with the tonemapping setting enabled vs disabled
<img width="1920" height="1079" alt="image" src="https://github.com/user-attachments/assets/88dd1156-f30c-4d48-bda6-90213c4750a7" />
<img width="1920" height="1079" alt="image" src="https://github.com/user-attachments/assets/d1f9b5f4-ed7d-466f-9f25-ff576b4ff5d2" />