### PR TITLE
feat: Add three-way options for mat_solidenergy_refract

### DIFF
--- a/layout/pages/main-menu/settings/video.xml
+++ b/layout/pages/main-menu/settings/video.xml
@@ -306,8 +306,9 @@
 					infomessage="#Settings_Misc_solenergy_refract_info"
 					hasdocspage="false"
 				>
-					<RadioButton group="misc_solidenergy" text="#Common_Off" value="0" />
-					<RadioButton group="misc_solidenergy" text="#Common_On" value="1" />
+					<RadioButton group="misc_solidenergy" text="#Settings_General_Disabled" value="0" />
+					<RadioButton group="misc_solidenergy" text="#Settings_General_Auto" value="1" />
+					<RadioButton group="misc_solidenergy" text="#Settings_General_Enabled" value="2" />
 				</SettingsEnum>
 				<SettingsEnum
 					text="#Settings_Portals_ghost"

--- a/localization/panorama_english.txt
+++ b/localization/panorama_english.txt
@@ -725,8 +725,8 @@
 
 		// Settings - Miscellaneous
 		"Settings_Misc_Title" 							"Miscellaneous"
-		"Settings_Misc_solenergy_refract"				"Solid Energy Refractions"
-		"Settings_Misc_solenergy_refract_info"			"Enables water-like refraction effects in fizzlers."
+		"Settings_Misc_solenergy_refract"				"Solid Energy (Fizzler) Refractions"
+		"Settings_Misc_solenergy_refract_info"			"Enables water-like refraction effects in fizzlers. \n<h2>Disabled</h2> Completely disables the effect. May result in smoother performance, but will cause levels to not look as the author intended.\n<h2>Auto</h2> Disabled for standard fizzlers, but enabled if the map author specifically requests it.\n<h2>Enabled</h2> Enables the effect for all fizzlers and author-requested materials.\n"
 		"Settings_Misc_ViewmodelOffset_X"				"Viewmodel Offset (X)"
 		"Settings_Misc_ViewmodelOffset_X_info"			"Offset the position of the Viewmodel in the X axis by this amount in Hammer Units (HU)"
 		"Settings_Misc_ViewmodelOffset_Y"				"Viewmodel Offset (Y)"


### PR DESCRIPTION
Changes the refraction option to a three-way, allowing mappers to set materials to turn on refraction even for users who don't want it enabled for regular fizzlers.