### PR TITLE
caption font menu changes 

### DIFF
--- a/layout/pages/main-menu/settings/audio.xml
+++ b/layout/pages/main-menu/settings/audio.xml
@@ -146,12 +146,12 @@
 					tags="cc,closecaption,captions,audio,font"
 					submitoverride="$.DispatchEvent('ReloadCCSettings')"
 				>
-					<Label text="#Settings_ClosedCaptions_Font_Lexend" value="0" id="ccfont0" />
-					<Label text="#Settings_ClosedCaptions_Font_U0001" value="1" id="ccfont1" />
-					<Label text="#Settings_ClosedCaptions_Font_GorDIN" value="2" id="ccfont2" />
-					<Label text="#Settings_ClosedCaptions_Font_Verdana" value="3" id="ccfont3" />
-					<Label text="#Settings_ClosedCaptions_Font_NotoSans" value="4" id="ccfont4" />
-					<Label text="#Settings_ClosedCaptions_Font_Stratum2" value="5" id="ccfont5" />
+					<Label text="#Settings_ClosedCaptions_Font_Lexend" class="settings-font-lexend" value="0" id="ccfont0" />
+					<Label text="#Settings_ClosedCaptions_Font_U0001" class="settings-font-univers" value="1" id="ccfont1" />
+					<Label text="#Settings_ClosedCaptions_Font_GorDIN" class="settings-font-gordin" value="2" id="ccfont2" />
+					<Label text="#Settings_ClosedCaptions_Font_Verdana" class="settings-font-verdana" value="3" id="ccfont3" />
+					<Label text="#Settings_ClosedCaptions_Font_NotoSans" class="settings-font-notosans" value="4" id="ccfont4" />
+					<Label text="#Settings_ClosedCaptions_Font_Stratum2" class="settings-font-stratum2" value="5" id="ccfont5" />
 				</SettingsEnumDropDown>
 
 				<SettingsSlider

--- a/layout/pages/main-menu/settings/input.xml
+++ b/layout/pages/main-menu/settings/input.xml
@@ -154,7 +154,7 @@
 					<SettingsKeyBinder text="#Keybind_Paintgun_NextPaint" bind="nextpaint" tags="attack,use,interact" />
 					<SettingsKeyBinder text="#Keybind_Paintgun_PrevPaint" bind="prevpaint" tags="attack,use,interact" />
 				</Panel>
-				<Panel class="full-width flow-right settings-row-separator">
+				<!-- <Panel class="full-width flow-right settings-row-separator">
 					<SettingsKeyBinder text="#Keybind_Weapon_Category_1" bind="slot1" tags="slot1" />
 					<SettingsKeyBinder text="#Keybind_Weapon_Category_2" bind="slot2" tags="slot2" />
 				</Panel>
@@ -165,7 +165,7 @@
 				<Panel class="full-width flow-right settings-row-separator">
 					<SettingsKeyBinder text="#Keybind_Weapon_Category_5" bind="slot5" tags="slot5" />
 					<SettingsKeyBinder text="#Keybind_Weapon_Category_6" bind="slot6" tags="slot6" />
-				</Panel>
+				</Panel> -->
 
 				<Label class="settings-group__subtitle" text="#Settings_Keybinds_MP_COOP" />
 

--- a/localization/panorama_english.txt
+++ b/localization/panorama_english.txt
@@ -416,7 +416,13 @@
 
 		// Storm - CC System Rewrite
 		"Settings_ClosedCaptions_Font"						"Font"
-		"Settings_ClosedCaptions_Font_info"					"Determines which typeface to use for on-screen subtitles and closed captions.\n<movie src=\"file://{videos}/settings/cc_font.webm\" />"
+		"Settings_ClosedCaptions_Font_info"					"Determines which typeface to use for on-screen subtitles and closed captions. 
+		<font class=\"settings-font-lexend\"><h2>Lexend (P2:CE / Strata Source)</h2>It's been a long time. How have you been?</font> 
+		<font class=\"settings-font-univers\"><h2>Univers (Portal 2)</h2>I've been really busy being dead. You know, after you MURDERED ME.</font> 
+		<font class=\"settings-font-gordin\"><h2>DIN 1451 / GorDIN (Half-Life 2)</h2>Okay. Look. We both said a lot of things that youre going to regret.</font>
+		<font class=\"settings-font-verdana\"><h2>Verdana (Legacy)</h2>But I think we can put our differences behind us. For science. You monster.</font> 
+		<font class=\"settings-font-notosans\"><h2>Noto Sans (Deck Gamepad UI)</h2>I will say, though, that since you went to all the trouble of waking me up, you must really, really love to test.</font> 
+		<font class=\"settings-font-stratum2\"><h2>Stratum2 (CS:GO)</h2>I love it too. Theres just one small thing we need to take care of first.</font>\n "
 		"Settings_ClosedCaptions_Font_Lexend"				"Lexend (P2:CE / Strata Source)"
 		"Settings_ClosedCaptions_Font_U0001"				"Univers (Portal 2)"
 		"Settings_ClosedCaptions_Font_GorDIN"				"DIN 1451 / GorDIN (Half-Life 2)"
@@ -676,7 +682,7 @@
 		"Settings_Portal1_compat" 						"Portal 1 Compatibility Mode"
 		"Settings_Portal1_compat_info" 					"Enables backwards compatibility with Portal 1 maps."
 		"Settings_Portal1_xhair" 						"Crosshair Style"
-		"Settings_Portal1_xhair_info" 					"Changes portal gun crosshair behavior.\n<h2>Portal 2 Style</h2>Will only display placed portals.\n<h2>Portal 1 Style</h2>Will display placed portals and a circular marker determining whether portals can be placed on a specific surface."
+		"Settings_Portal1_xhair_info" 					"Changes portal gun crosshair behavior.\n<h2>Portal 2 Style</h2>Will display placed portals.\n<h2>Portal 1 Style</h2>Will display whether portals can be placed on the aimed surface, along with a circular marker showing the last shot portal."
 		"Settings_Portal1_xhair_p2" 					"Portal 2 Style"
 		"Settings_portal1_xhair_p1" 					"Portal 1 Style"
 		"Settings_Portal1_xhair_scale" 					"Crosshair Scale"

--- a/styles/pages/settings/settings.scss
+++ b/styles/pages/settings/settings.scss
@@ -583,3 +583,53 @@ $page-width: 1920px - $rightnav-width;
 .settings-row-separator {
 	border-bottom: 1px solid $base-900;
 }
+
+Label.settings-font-lexend {
+	font-family: 'Lexend';
+}
+
+Label.settings-font-univers {
+	font-family: 'Univers LT Std 47 Cn Lt';
+}
+
+Label.settings-font-gordin {
+	font-family: 'GorDIN';
+	line-height: 24px;
+}
+
+Label.settings-font-verdana {
+	font-family: 'Verdana';
+}
+
+Label.settings-font-notosans {
+	font-family: 'Noto Sans';
+}
+
+Label.settings-font-stratum2 {
+	font-family: 'Stratum2';
+}
+
+.settings-font-lexend {
+	font-family: 'Lexend';
+}
+
+.settings-font-univers {
+	font-family: 'Univers LT Std 47 Cn Lt';
+}
+
+.settings-font-gordin {
+	font-family: 'GorDIN';
+	line-height: 24px;
+}
+
+.settings-font-verdana {
+	font-family: 'Verdana';
+}
+
+.settings-font-notosans {
+	font-family: 'Noto Sans';
+}
+
+.settings-font-stratum2 {
+	font-family: 'Stratum2';
+}


### PR DESCRIPTION
this changes the caption font dropdown to use its own respective font, along with using the fonts directly in the description to better aid in distinguishing them.
<img width="1919" height="1078" alt="image" src="https://github.com/user-attachments/assets/dc79df71-4615-45da-851c-5a721290896e" />

this pr also corrects a mistake in the p1 crosshair description, and comments out the currently unusable weapon slot binds