### PR TITLE
New Campaign Loading Screen Meta Keys And Updated Bottom Right Loading Indicator

### DIFF
--- a/layout/pages/loading-screen.xml
+++ b/layout/pages/loading-screen.xml
@@ -20,17 +20,16 @@
 			src=""
 			scaling="stretch-to-cover-preserve-aspect"
 		/>
+		<Movie id="BackgroundMovie" class="loadingscreen__movie" controls="full" autoplay="onload" repeat="true" hittest="false" />
 
-		<!-- todo: set the logo dynamically -->
-		<!-- Pivot (26/11/2025): Re-enabling this in the hopes that custom campaigns will be able to override this -->
-		<Panel class="loadingscreen__logo">
+		<Panel id="Spinner" class="loadingscreen__logo">
 			<AnimatedImageStrip
+				id="SpinnerStrip"
 				animating="true"
 				defaultframe="0"
 				frametime="125ms"
 				src=""
-				defaultsrc="file://{images}/menu/p2ce/spinner_strip.tga"
-				scaling="stretch-to-cover-preserve-aspect"
+				scaling="stretch-to-fit-preserve-aspect"
 			/>
 			<Image
 				id="Logo"
@@ -43,12 +42,8 @@
 		</Panel>
 
 		<Panel class="loadingscreen__fade--dark" />
-		<Panel id="LoadingScreenContents" class="loadingscreen__contents" />
 
-		<Panel id="" class="full-width full-height">
-		</Panel>
-
-		<Panel class="loadingscreen__progress-panel">
+		<Panel id="ProgressPanel" class="loadingscreen__progress-panel">
 			<Panel class="loadingscreen__grid1" hittest="false" />
 			<Panel class="loadingscreen__grid2" hittest="false" />
 			<Panel class="full-width flow-down vertical-align-center">

--- a/layout/pages/main-menu/dev/controls-library.xml
+++ b/layout/pages/main-menu/dev/controls-library.xml
@@ -591,11 +591,11 @@
 				<ProgressBar id="ProgressBar1" class="progressbar" min="0.0" max="1.0" style="width: 400px;" />
 			</Panel>
 
-			<!-- <Label class="text-h3 mt-3" text="Movie (WIP)" /> -->
-			<!-- <Panel class="row my-3" style="height:360px;width:1080px;">
-				<Movie src="file://{resources}/videos/backgrounds/MomentumDark.webm" autoplay="onload" controls="full" style="width:540px;"/>
-				<Movie src="file://{resources}/videos/backgrounds/MomentumDark.webm" autoplay="onload" controls="minimal" style="width:540px;"/>
-			</Panel> -->
+			<Label class="text-h3 mt-3" text="Movie (WIP)" />
+			<Panel class="row my-3" style="height:360px;width:1080px;">
+				<Movie src="file://{resources}/videos/settings/cl_fov.webm" autoplay="onload" controls="full" style="width:540px;"/>
+				<Movie src="file://{resources}/videos/settings/ss_splitmode.webm" autoplay="onload" controls="minimal" style="width:540px;"/>
+			</Panel>
 
 			<Label class="text-h3 mt-3" text="Context Menus" />
 			<Panel class="row my-3">

--- a/scripts/pages/loading-screen.ts
+++ b/scripts/pages/loading-screen.ts
@@ -6,15 +6,19 @@ class LoadingScreenController {
 	static bgEvent: number | undefined = undefined;
 	static bgEvent2: number | undefined = undefined;
 
-	static progressBar = $('#ProgressBar') as ProgressBar;
-	static bgImage1 = $('#BackgroundMapImage1') as Image;
-	static bgImage2 = $('#BackgroundMapImage2') as Image;
-	static logo = $<Image>('#Logo');
+	static progressBar = $<ProgressBar>('#ProgressBar')!;
+	static progressPanel = $<Panel>('#ProgressPanel')!;
+	static bgImage1 = $<Image>('#BackgroundMapImage1')!;
+	static bgImage2 = $<Image>('#BackgroundMapImage2')!;
+	static bgMovie = $<Movie>('#BackgroundMovie')!;
+	static logo = $<Image>('#Logo')!;
+	static spinner = $<Image>('#Spinner')!;
+	static spinnerImage = $<AnimatedImageStrip>('#SpinnerStrip')!;
 	static beBlankIfInvalid = false;
 
 	static init() {
 		$.DispatchEvent('MainMenuHideFeaturedOverlay');
-		
+
 		this.progressBar.value = 0;
 
 		this.bgImage2.RemoveClass('loadingscreen__backgroundshowanim');
@@ -66,30 +70,51 @@ class LoadingScreenController {
 		const c: CampaignPair | null = CampaignAPI.FindCampaign(mapGroup);
 		const meta = CampaignAPI.GetCampaignMeta(mapGroup); // SLOW
 
-		// set spinner
-		if (c) {
-			const img = meta ? meta.get(CampaignMeta.SQUARE_LOGO) : undefined;
-			if (this.logo) {
+		if (c && meta) {
+			// get relevant information
+
+			// Show/Hide the panel for the progress bar.
+			this.progressPanel.visible = true;
+			if ((meta.get(CampaignMeta.SHOW_PROGRESS_BAR) ?? 'true').toLowerCase() === 'false') {
+				this.progressPanel.visible = false;
+			}
+
+			// Show/Hide the panel that holds the spinner.
+			this.spinner.visible = true;
+			if ((meta.get(CampaignMeta.SHOW_SPINNER) ?? 'true').toLowerCase() === 'false') {
+				this.spinner.visible = false;
+			}
+
+			// Spinner
+			{
+				const img = meta ? meta.get(CampaignMeta.SQUARE_LOGO) : undefined;
 				if (img) {
 					this.logo.SetImage(`${getCampaignAssetPath(c)}${img}`);
 				} else {
 					this.logo.SetImage('file://{images}/menu/p2ce/logo.png');
 				}
+				const spinnerImg = meta ? meta.get(CampaignMeta.SPINNER_IMAGE) : undefined;
+				if (spinnerImg)
+					this.spinnerImage.SetImage(`${getCampaignAssetPath(c)}${spinnerImg}`);
+				else
+					this.spinnerImage.SetImage('file://{images}/menu/p2ce/spinner_strip.tga');
 			}
-		} else {
-			if (this.logo) {
-				this.logo.SetImage('file://{images}/menu/p2ce/logo.png');
-			}
-		}
 
-		if (c && meta) {
-			// get relevant information
-
-			if (this.logo) {
+			// Logo padding
+			{
 				const pad = Number(meta.get(CampaignMeta.LOADING_LOGO_PAD));
 				if (!isNaN(pad)) {
 					this.logo.style.padding = `${pad}px`;
 				}
+			}
+
+			// Get transition/loading screen movie/video to play.
+			const movie = meta.get(useTransitScreen ? CampaignMeta.TRANSITION_SCREEN_MOVIE : CampaignMeta.LOADING_SCREEN_MOVIE) ?? '';
+			if (movie.length > 0) {
+				this.bgMovie.SetMovie(`${getCampaignAssetPath(c)}${movie}`);
+				this.bgMovie.visible = true;
+			} else {
+				this.bgMovie.visible = false;
 			}
 
 			// applies image and sets panel if it's valid
@@ -127,8 +152,15 @@ class LoadingScreenController {
 				this.bgImage2.visible = false;
 			}
 		} else {
+			// No campaign, reset to default look
+			this.progressPanel.visible = true;
+			this.spinner.visible = true;
 			this.bgImage1.visible = false;
 			this.bgImage2.visible = false;
+			this.bgMovie.visible = false;
+			this.logo.style.padding = '0px';
+			this.logo.SetImage('file://{images}/menu/p2ce/logo.png');
+			this.spinnerImage.SetImage('file://{images}/menu/p2ce/spinner_strip.tga');
 		}
 	}
 

--- a/scripts/types-p2ce/ui-state-types.d.ts
+++ b/scripts/types-p2ce/ui-state-types.d.ts
@@ -27,8 +27,10 @@ declare const enum CampaignMeta {
 	SQUARE_LOGO = 'square_logo',
 	DESC = 'desc',
 	AUTHOR = 'author',
-	TRANSITION_SCREEN = 'transition_screen',
 	LOADING_SCREEN = 'loading_screen',
+	TRANSITION_SCREEN = 'transition_screen',
+	LOADING_SCREEN_MOVIE = 'loading_movie',
+	TRANSITION_SCREEN_MOVIE = 'transition_movie',
 	CHAPTER_THUMBNAIL = 'thumbnail',
 	CHAPTER_DISPLAY_MODE = 'chapter_display_mode',
 	BG_MAP = 'background_map',
@@ -38,7 +40,10 @@ declare const enum CampaignMeta {
 	MAP_LIST_IMG = 'img',
 	MAP_LIST_TITLE = 'title',
 	LOGO_HEIGHT = 'full_logo_size_preset',
-	CHAPTER_LOCKED_TITLE = 'locked_title'
+	CHAPTER_LOCKED_TITLE = 'locked_title',
+	SHOW_PROGRESS_BAR = 'show_progress_bar',
+	SHOW_SPINNER = 'show_spinner',
+	SPINNER_IMAGE = 'spinner_image'
 }
 
 declare const enum CampaignLogoSizePreset {

--- a/styles/pages/loading-screen.scss
+++ b/styles/pages/loading-screen.scss
@@ -26,6 +26,11 @@
 		opacity: 0;
 	}
 
+	&__movie {
+		width: 1920px;
+		height: 1080px;
+	}
+
 	&__contents {
 		opacity: 1;
 

--- a/styles/pages/main-menu/main-menu.scss
+++ b/styles/pages/main-menu/main-menu.scss
@@ -86,16 +86,10 @@ $pane-move-time: 0.1s;
 .loading-indicator {
 	horizontal-align: right;
 	vertical-align: bottom;
-	padding: 12px 14px;
+	padding: 10px 15px;
 	margin: 15px;
-	margin-right: 16px;
-	background-color: black;
-	border-radius: 6px;
-	& > Label {
-		font-family: Verdana;
-		font-size: 16px;
-		color: white;
-	}
+	background-color: $base-gradient;
+	border: $menu-pane-border;
 }
 
 .mainmenu {


### PR DESCRIPTION
New meta keys have been added for the loading screen which allow a video/movie/webm to be played instead of having one or two static images. Note though, that loading times are usually still short, so there might not be much shown if one is played. There are also two new meta keys for enabling or disabling the progress bar panel and loading spinner at the top right of the loading screen. This will also remove the icon used for the spinner.

The bottom-right loading indicator sometimes used has been updated to better match the UI style of the rest of the P2:CE UI.