### PR TITLE
Token consistency for glados lines in CC font option string

### DIFF
--- a/localization/panorama_english.txt
+++ b/localization/panorama_english.txt
@@ -414,12 +414,12 @@
 		// Storm - CC System Rewrite
 		"Settings_ClosedCaptions_Font"						"Font"
 		"Settings_ClosedCaptions_Font_info"					"Determines which typeface to use for on-screen subtitles and closed captions.
-		<font class=\"settings-font-lexend\"><h2>Lexend (P2:CE / Strata Source)</h2>It's been a long time. How have you been?</font>
-		<font class=\"settings-font-univers\"><h2>Univers (Portal 2)</h2>I've been really busy being dead. You know, after you MURDERED ME.</font>
-		<font class=\"settings-font-gordin\"><h2>DIN 1451 / GorDIN (Half-Life 2)</h2>Okay. Look. We both said a lot of things that you're going to regret.</font>
-		<font class=\"settings-font-verdana\"><h2>Verdana (Legacy)</h2>But I think we can put our differences behind us. For science. You monster.</font>
-		<font class=\"settings-font-notosans\"><h2>Noto Sans (Deck Gamepad UI)</h2>I will say, though, that since you went to all the trouble of waking me up, you must really, really love to test.</font>
-		<font class=\"settings-font-stratum2\"><h2>Stratum2 (CS:GO)</h2>I love it too. There's just one small thing we need to take care of first.</font>\n "
+		<font class=\"settings-font-lexend\"><h2>Lexend (P2:CE / Strata Source)</h2><font color=\"rgb(163,193,173)\"><b>GLaDOS:</b> Oh, it's <i>you.</i></font></font>
+		<font class=\"settings-font-univers\"><h2>Univers (Portal 2)</h2><font color=\"rgb(163,193,173)\"><b>GLaDOS:</b> It's been a long time. How have you been?</font></font>
+		<font class=\"settings-font-gordin\"><h2>DIN 1451 / GorDIN (Half-Life 2)</h2><font color=\"rgb(163,193,173)\"><b>GLaDOS:</b> I've been really busy being dead. You know, after you murdered me?</font></font>
+		<font class=\"settings-font-verdana\"><h2>Verdana (Legacy)</h2><font color=\"rgb(163,193,173)\"><b>GLaDOS:</b> Okay, look. We both said a lot of things that you're going to regret. But I think we can put our differences behind us... for science, you monster.</font></font>
+		<font class=\"settings-font-notosans\"><h2>Noto Sans (Deck Gamepad UI)</h2><font color=\"rgb(163,193,173)\"><b>GLaDOS:</b> I will say, though, that since you went through all the trouble of waking me up, you must really, <i>really</i> love to test.</font></font>
+		<font class=\"settings-font-stratum2\"><h2>Stratum2 (CS:GO)</h2><font color=\"rgb(163,193,173)\"><b>GLaDOS:</b> I love it, too. There's just one small thing we need to take care of first.</font></font>\n"
 		"Settings_ClosedCaptions_Font_Lexend"				"Lexend (P2:CE / Strata Source)"
 		"Settings_ClosedCaptions_Font_U0001"				"Univers (Portal 2)"
 		"Settings_ClosedCaptions_Font_GorDIN"				"DIN 1451 / GorDIN (Half-Life 2)"


### PR DESCRIPTION
It's on the tin. Color-codes GLaDOS tokens and matches them up with the version in `subtitles_english.kv3` for the CC font option.

<img width="1920" height="1080" alt="p2ce_2026-09-07_01-08-55" src="https://github.com/user-attachments/assets/85959df9-d390-463e-a1fe-62a77d7492bd" />
